### PR TITLE
fix: migrate Google Analytics to GA4 measurement ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ permalink: pretty
 title: Malachi Soord
 tagline: In a beautiful place out in the country
 paginate: 5
-analytics_id: UA-15939659-3
+analytics_id: G-FGVL6K7ML7
 ads_on: false
 adsense_id: ca-pub-1828124334332563
 timezone: Europe/Berlin


### PR DESCRIPTION
Universal Analytics (UA-15939659-3) stopped processing hits in July 2023. Migrate to GA4 measurement ID G-FGVL6K7ML7 so analytics actually collects data again.