### PR TITLE
fix: dark mode flash of light theme and toggle behavior

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,20 @@
   <link rel="shortcut icon" href="{{ site.baseurl }}/assets/img/favicon.ico">
   <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ site.baseurl }}/atom.xml">
   <meta name="theme-color" content="#37646f" />
+  <script>
+    // Apply the saved/system dark mode before first paint to avoid a flash of light theme.
+    window.isSystemDarkMode = function () {
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    };
+    window.getInitialDarkMode = function () {
+      var stored = localStorage.getItem('darkMode');
+      if (stored === null) return isSystemDarkMode();
+      try { return JSON.parse(stored); } catch (e) { return isSystemDarkMode(); }
+    };
+    if (getInitialDarkMode()) {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
   {% seo %}
   {% feed_meta %}
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,8 +25,8 @@
         </ul>
         <ul class="controls">
         <li>
-          <a href="#" id="themeChange" class="nav-item theme">
-            <i class="fas fa-moon"></i>
+          <a href="#" id="themeChange" class="nav-item theme" aria-label="Toggle dark mode" title="Toggle dark mode">
+            <i class="fas fa-moon" id="themeIcon"></i>
           </a>
         </li>
         </ul>
@@ -57,29 +57,26 @@
         });
       }
 
-      function isSystemDarkMode() {
-        return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-      }
-
       function setDarkMode(darkMode) {
-        if (darkMode) {
-          document.body.classList.add("dark-mode");
-        } else {
-          document.body.classList.remove("dark-mode");
+        document.documentElement.classList.toggle('dark-mode', darkMode);
+        localStorage.setItem('darkMode', darkMode);
+        const themeIcon = document.getElementById('themeIcon');
+        if (themeIcon) {
+          themeIcon.className = darkMode ? 'fas fa-sun' : 'fas fa-moon';
         }
-        localStorage.setItem("darkMode", darkMode);
         changeGiscusTheme(darkMode);
       }
 
       function changeTheme() {
-        let darkMode = JSON.parse(localStorage.getItem("darkMode"));
-        darkMode = !darkMode;
-        setDarkMode(darkMode);
+        setDarkMode(!getInitialDarkMode());
       }
 
-      document.addEventListener("DOMContentLoaded", function(event) {
-        document.getElementById("themeChange").addEventListener("click", changeTheme);
-        setDarkMode(JSON.parse(localStorage.getItem("darkMode") || isSystemDarkMode()));
+      document.addEventListener('DOMContentLoaded', function(event) {
+        document.getElementById('themeChange').addEventListener('click', function(e) {
+          e.preventDefault();
+          changeTheme();
+        });
+        setDarkMode(getInitialDarkMode());
       });
     </script>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,8 @@
         <ul class="controls">
         <li>
           <a href="#" id="themeChange" class="nav-item theme" aria-label="Toggle dark mode" title="Toggle dark mode">
-            <i class="fas fa-moon" id="themeIcon"></i>
+            <i class="fas fa-moon" id="themeIconMoon"></i>
+            <i class="fas fa-sun" id="themeIconSun"></i>
           </a>
         </li>
         </ul>
@@ -60,10 +61,6 @@
       function setDarkMode(darkMode) {
         document.documentElement.classList.toggle('dark-mode', darkMode);
         localStorage.setItem('darkMode', darkMode);
-        const themeIcon = document.getElementById('themeIcon');
-        if (themeIcon) {
-          themeIcon.className = darkMode ? 'fas fa-sun' : 'fas fa-moon';
-        }
         changeGiscusTheme(darkMode);
       }
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -18,6 +18,7 @@ html {
   font-family: $root-font-family;
   font-size: $root-font-size;
   line-height: $root-line-height;
+  color-scheme: light;
 
   @media (min-width: $large-breakpoint) {
     font-size: $large-font-size;
@@ -77,11 +78,16 @@ tbody tr:nth-child(odd) th {
   background-color: #f9f9f9;
 }
 
-.dark-mode {
+html.dark-mode {
+  color-scheme: dark;
+}
+
+html.dark-mode body {
   background: $dark-body-bg;
-
   color: $dark-body-color;
+}
 
+.dark-mode {
   .masthead-title {
     color: $dark-heading-title;
 
@@ -89,7 +95,6 @@ tbody tr:nth-child(odd) th {
       color: $dark-body-color;
     }
   }
-
 
   nav {
     background-color: $dark-nav-color;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -99,6 +99,14 @@ html.dark-mode body {
   nav {
     background-color: $dark-nav-color;
 
+    #themeIconMoon {
+      display: none;
+    }
+
+    #themeIconSun {
+      display: inline;
+    }
+
     a {
       background-color: rgba(255, 255, 255, 0.08);
 

--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -38,6 +38,10 @@ nav {
             &.theme {
                 padding: 0.45rem 0.75rem;
             }
+
+            #themeIconSun {
+                display: none;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes the dark-mode jank from the site review:

- **FOUC fix**: apply saved/system dark mode in `<head>` before first paint — no more flash of light theme for dark-mode users
- **Class on `<html>`**: toggle moves from `document.body` to `document.documentElement` so head-time and runtime scripts stay consistent
- **Toggle link**: `preventDefault()` so clicking no longer scrolls to top / appends `#` to URL; adds `aria-label`/title
- **Icon feedback**: moon/sun icon swaps to reflect current theme
- **`color-scheme`**: scrollbars and form controls now follow dark mode (`color-scheme: dark` on `html.dark-mode`)

Verified with a local `jekyll build` — head script renders before first paint, Sass compiles, class lands on `<html>`.