### PR TITLE
chore: migrate Sass @import to @use

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,8 +13,6 @@ url: https://www.malachisoord.com
 sass:
   sass_dir: _sass
   style: compressed
-  silence_deprecations:
-    - import
 # About/contact
 author:
   name: Malachi Soord

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -2,6 +2,8 @@
 //
 // Update the foundational and global aspects of the page.
 
+@use "variables" as *;
+
 * {
   -webkit-box-sizing: border-box;
      -moz-box-sizing: border-box;

--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -3,6 +3,8 @@
 // Inline and block-level code snippets. Includes tweaks to syntax highlighted
 // snippets from Pygments/Rouge and Gist embeds.
 
+@use "variables" as *;
+
 code,
 pre {
   font-family: $code-font-family;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -2,6 +2,8 @@
 //
 // Styles for managing the structural hierarchy of the site.
 
+@use "variables" as *;
+
 .container {
   max-width: $max-container-width;
   padding-left:  1.5rem;

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -2,6 +2,9 @@
 //
 // Super small header above the content for site name and short description.
 
+@use "variables" as *;
+@use "mixins" as *;
+
 .masthead {
     padding-top: 1rem;
     padding-bottom: 1rem;

--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 nav {
     background: $nav-color;
     margin-bottom:1em;

--- a/_sass/_posts.scss
+++ b/_sass/_posts.scss
@@ -3,6 +3,8 @@
 // Each post is wrapped in `.post` and is used on default and post layouts. Each
 // page is wrapped in `.page` and is only used on the page layout.
 
+@use "variables" as *;
+
 .page,
 .post {
   margin: 1em 0;

--- a/_sass/_type.scss
+++ b/_sass/_type.scss
@@ -2,6 +2,8 @@
 //
 // Headings, body text, lists, and other misc typographic elements.
 
+@use "variables" as *;
+
 h1, h2, h3, h4, h5, h6 {
   margin-bottom: .5rem;
   font-weight: 600;

--- a/styles.scss
+++ b/styles.scss
@@ -17,16 +17,16 @@
 // Designed, built, and released under MIT license by @mdo. Learn more at
 // https://github.com/poole/poole.
 
-@import "variables";
-@import "base";
-@import "mixins";
-@import "nav";
-@import "type";
-@import "syntax";
-@import "code";
-@import "layout";
-@import "masthead";
-@import "posts";
-@import "pagination";
-@import "message";
-@import "comments";
+@use "variables";
+@use "base";
+@use "mixins";
+@use "nav";
+@use "type";
+@use "syntax";
+@use "code";
+@use "layout";
+@use "masthead";
+@use "posts";
+@use "pagination";
+@use "message";
+@use "comments";


### PR DESCRIPTION
Migrate styles.scss and partials from deprecated @import to @use; drop silence_deprecations. Verified: built styles.css is byte-identical before/after.