### PR TITLE
chore: update FontAwesome to v7.3.1

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -90,6 +90,6 @@
     {% if site.adsense_id and site.ads_on %}
     <script data-ad-client="{{ site.adsense_id }}" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
     {% endif %}
-    <script defer src="https://use.fontawesome.com/releases/v7.0.1/js/all.js"></script>
+    <script defer src="https://use.fontawesome.com/releases/v7.3.1/js/all.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Bump FontAwesome CDN from v7.0.1 to v7.3.1 (current stable, 2026-07-15).

Verified: 7.3.1 URL resolves (HTTP 200), local `jekyll build` clean.