### PR TITLE
chore: add branch protection and conventional commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,12 @@ repos:
       - id: trailing-whitespace
       - id: check-toml
       - id: check-executables-have-shebangs
+      - id:  no-commit-to-branch
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.16.5
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.38.0
     hooks:


### PR DESCRIPTION
Adds two pre-commit hooks:

- `no-commit-to-branch`: blocks commits to `master`/`main`
- `commitizen`: enforces conventional commit messages on commit-msg