### PR TITLE
chore: use precompiled ruby in mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
+[settings]
+ruby.compile = false
+
 [tools]
 pre-commit = "4.6.1"
 


### PR DESCRIPTION
Set `ruby.compile = false` so mise downloads prebuilt Ruby binaries instead of compiling from source.

**Why**
- Faster toolchain installs locally and in CI (`jdx/mise-action@v4`)
- `ruby.compile` already defaults to `false`; this pins it explicitly per-repo so a global default flip can't silently reintroduce source builds

CI impact: the `build` job runs `mise install` via `jdx/mise-action@v4`, which also caches tool installs by default — precompiled ruby makes that cache hit fast.